### PR TITLE
결제 API

### DIFF
--- a/src/main/java/com/reform/wiz/controller/PaymentController.java
+++ b/src/main/java/com/reform/wiz/controller/PaymentController.java
@@ -1,0 +1,40 @@
+package com.reform.wiz.controller;
+
+import com.reform.wiz.dto.PaymentDTO;
+import com.reform.wiz.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/payment")
+@Log4j2
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    // 결제 전체 조회
+    @GetMapping
+    public ResponseEntity<List<PaymentDTO>> getAllPayments() {
+        List<PaymentDTO> list = paymentService.getAllPayments();
+        return ResponseEntity.ok(list);
+    }
+
+    // 결제 승인
+    @PostMapping("/approve")
+    public ResponseEntity<PaymentDTO> approvePayment(@RequestBody PaymentDTO dto) {
+        PaymentDTO saved = paymentService.approvePayment(dto);
+        return ResponseEntity.ok(saved);
+    }
+
+    // 결제 취소
+    @PutMapping("/cancel")
+    public ResponseEntity<PaymentDTO> cancelPayment(@RequestParam Long pno) {
+        PaymentDTO canceled = paymentService.cancelPayment(pno);
+        return ResponseEntity.ok(canceled);
+    }
+}

--- a/src/main/java/com/reform/wiz/dto/PaymentDTO.java
+++ b/src/main/java/com/reform/wiz/dto/PaymentDTO.java
@@ -1,0 +1,50 @@
+package com.reform.wiz.dto;
+
+import com.reform.wiz.entity.PaymentEntity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentDTO {
+
+    private Long pno;
+
+    private Integer bno; // 게시글 번호
+
+    private Integer amount;
+
+    private String detail;
+
+    private String type;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime canceledAt;
+
+    public PaymentDTO(PaymentEntity entity) {
+        this.pno = entity.getPno();
+        this.bno = entity.getBno();
+        this.amount = entity.getAmount();
+        this.detail = entity.getDetail();
+        this.type = entity.getType();
+        this.createdAt = entity.getCreatedAt();
+        this.canceledAt = entity.getCanceledAt();
+    }
+
+    public PaymentEntity toEntity() {
+        return PaymentEntity.builder()
+                .pno(this.pno)
+                .bno(this.bno)
+                .amount(this.amount)
+                .detail(this.detail)
+                .type(this.type)
+                .createdAt(this.createdAt != null ? this.createdAt : LocalDateTime.now())
+                .canceledAt(this.canceledAt)
+                .build();
+    }
+}

--- a/src/main/java/com/reform/wiz/entity/PaymentEntity.java
+++ b/src/main/java/com/reform/wiz/entity/PaymentEntity.java
@@ -5,6 +5,9 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 @Entity
 @Table(name = "payment")
 @Getter
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@EntityListeners(AuditingEntityListener.class)
 public class PaymentEntity {
 
     @Id
@@ -30,16 +34,12 @@ public class PaymentEntity {
     @Column(nullable = false)
     private String type;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "canceled_at")
     private LocalDateTime canceledAt;
-
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = LocalDateTime.now();
-    }
 
     public void cancel() {
         this.canceledAt = LocalDateTime.now();

--- a/src/main/java/com/reform/wiz/entity/PaymentEntity.java
+++ b/src/main/java/com/reform/wiz/entity/PaymentEntity.java
@@ -1,0 +1,64 @@
+package com.reform.wiz.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class PaymentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pno;
+
+    @Column(nullable = false)
+    private Integer bno; // 게시글 번호 (board.bno 참조)
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private String detail;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        this.canceledAt = LocalDateTime.now();
+    }
+
+    public void changeAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public void changeDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public void changeType(String type) {
+        this.type = type;
+    }
+
+    // TODO: 추후 bidNo가 외래키로 들어오면 아래처럼 연관관계 매핑할 예정
+    // @ManyToOne
+    // @JoinColumn(name = "bidNo")
+    // private BidEntity bid;
+}

--- a/src/main/java/com/reform/wiz/repository/PaymentRepository.java
+++ b/src/main/java/com/reform/wiz/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.reform.wiz.repository;
+
+import com.reform.wiz.entity.PaymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+
+}

--- a/src/main/java/com/reform/wiz/service/PaymentService.java
+++ b/src/main/java/com/reform/wiz/service/PaymentService.java
@@ -1,0 +1,45 @@
+package com.reform.wiz.service;
+
+import com.reform.wiz.dto.PaymentDTO;
+import com.reform.wiz.entity.PaymentEntity;
+import com.reform.wiz.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    // 결제 승인 (Create)
+    @Transactional
+    public PaymentDTO approvePayment(PaymentDTO dto) {
+        log.info("결제 승인 요청: {}", dto);
+        PaymentEntity entity = dto.toEntity();
+        PaymentEntity saved = paymentRepository.save(entity);
+        return new PaymentDTO(saved);
+    }
+
+    // 결제 전체 조회 (Read)
+    @Transactional(readOnly = true)
+    public List<PaymentDTO> getAllPayments() {
+        List<PaymentEntity> result = paymentRepository.findAll();
+        return result.stream().map(PaymentDTO::new).collect(Collectors.toList());
+    }
+
+    // 결제 취소 (Update)
+    @Transactional
+    public PaymentDTO cancelPayment(Long pno) {
+        PaymentEntity entity = paymentRepository.findById(pno).orElseThrow(
+                () -> new IllegalArgumentException("해당 결제 내역이 존재하지 않습니다. pno=" + pno));
+        entity.cancel(); // canceled_at 갱신
+        return new PaymentDTO(entity);
+    }
+}

--- a/src/test/java/com/reform/wiz/repository/PaymentRepositoryTests.java
+++ b/src/test/java/com/reform/wiz/repository/PaymentRepositoryTests.java
@@ -1,0 +1,41 @@
+package com.reform.wiz.repository;
+
+import com.reform.wiz.entity.PaymentEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class PaymentRepositoryTests {
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Test
+    @Commit
+    public void testInsert() {
+        PaymentEntity entity = PaymentEntity.builder()
+                .bno(1)
+                .amount(50000)
+                .detail("테스트 결제")
+                .type("CARD")
+                .build();
+
+        paymentRepository.save(entity);
+    }
+
+    @Test
+    public void testRead() {
+        Long pno = 1L;
+        Optional<PaymentEntity> result = paymentRepository.findById(pno);
+        result.ifPresent(e -> System.out.println("결제 정보: " + e));
+    }
+}

--- a/src/test/java/com/reform/wiz/service/PaymentServiceTests.java
+++ b/src/test/java/com/reform/wiz/service/PaymentServiceTests.java
@@ -1,0 +1,55 @@
+package com.reform.wiz.service;
+
+import com.reform.wiz.dto.PaymentDTO;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+
+import java.util.List;
+
+@SpringBootTest
+@Log4j2
+public class PaymentServiceTests {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    /*
+     * [테스트 케이스]
+     * 📌 READ - 결제 조회
+     * 📌 CREATE - 결제 승인
+     * 📌 UPDATE - 결제 취소
+     */
+
+    // ✅ READ
+    @Test
+    @Commit
+    public void testApprove() {
+        PaymentDTO dto = new PaymentDTO();
+        dto.setBno(1);
+        dto.setAmount(100000);
+        dto.setDetail("서비스 테스트 결제");
+        dto.setType("CARD");
+
+        PaymentDTO saved = paymentService.approvePayment(dto);
+        log.info("Saved >>> {}", saved);
+    }
+
+    // ✅ CREATE
+    @Test
+    public void testGetAll() {
+        List<PaymentDTO> list = paymentService.getAllPayments();
+        log.info("All Payments >>> {}", list);
+    }
+
+    // ✅ UPDATE
+    @Test
+    @Commit
+    public void testCancel() {
+        Long pno = 1L; // 테스트용
+        PaymentDTO result = paymentService.cancelPayment(pno);
+        log.info("Canceled >>> {}", result);
+    }
+}


### PR DESCRIPTION
# 1. 결제 API 작성
- 결제 Entity (`PaymentEntity`) 정의
  - 입찰(Bid)과의 연관관계는 추후 매핑 예정 (현재는 bno 필드로 대체)
- PaymentDTO 생성: entity <-> dto 변환 지원
- Service/Repository/Controller 구현
  - `GET /api/v1/payment` : 결제 전체 조회
  - `POST /api/v1/payment/approve` : 결제 승인
  - `PUT /api/v1/payment/cancel?pno=1` : 결제 취소

# 2. 테스트 코드 작성
- `PaymentRepositoryTests.java`
  - 결제 저장(insert), 결제 조회(read) 기능 검증
- `PaymentServiceTests.java`
  - 결제 승인 (register)
  - 결제 전체 조회
  - 결제 취소 기능 테스트


# 특이사항
- `PaymentEntity.java` 
  - 입찰(Bid) 테이블과의 연관관계 설정 예정 (`@ManyToOne`)