### PR TITLE
[fix] 게시글 검색어 검색

### DIFF
--- a/src/main/java/com/reform/wiz/controller/BoardController.java
+++ b/src/main/java/com/reform/wiz/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.reform.wiz.controller;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,13 +51,19 @@ public class BoardController {
   public ResponseEntity<ApiResponse<PageResponseDTO<BoardDTO>>> getBoard(@RequestParam Map<String, String> param) {
     int page = Integer.parseInt(param.get("page"));
     int size = Integer.parseInt(param.get("size"));
+    String title = (String) (param.get("title"));
+    String content = (String) (param.get("content"));
+
+    Map<String, String> searchMap = new HashMap<>();
+    searchMap.put("title", title);
+    searchMap.put("content", content);
 
     PageRequestDTO dto = PageRequestDTO.builder()
         .page(page)
         .size(size)
         .build();
 
-    PageResponseDTO res = boardService.getAllByPage(dto.getPageable(Sort.by("bno")));
+    PageResponseDTO res = boardService.getAllByPage(dto.getPageable(Sort.by("bno")), searchMap);
     return ResponseEntity.ok(ApiResponse.success(res));
   }
 

--- a/src/main/java/com/reform/wiz/repository/BoardRepository.java
+++ b/src/main/java/com/reform/wiz/repository/BoardRepository.java
@@ -1,9 +1,12 @@
 package com.reform.wiz.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.reform.wiz.entity.BoardEntity;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
+  Page<BoardEntity> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
 
 }

--- a/src/main/java/com/reform/wiz/service/BoardService.java
+++ b/src/main/java/com/reform/wiz/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.reform.wiz.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -38,8 +39,11 @@ public class BoardService {
   }
 
   // 글 페이지당 조회
-  public PageResponseDTO<BoardDTO> getAllByPage(Pageable pageable) {
-    Page<BoardEntity> result = boardRepository.findAll(pageable);
+  public PageResponseDTO<BoardDTO> getAllByPage(Pageable pageable, Map<String, String> map) {
+    String title = map.get("title");
+    String content = map.get("content");
+
+    Page<BoardEntity> result = boardRepository.findByTitleContainingOrContentContaining(title, content, pageable);
 
     Page<BoardDTO> dtoPage = result.map(BoardDTO::new);
 


### PR DESCRIPTION
### 작업내용
- 게시글 검색시 페이징처리
   > 제목, 내용 구분 없이 검색어를 통해 리스트 조회