### PR TITLE
feat: 마이페이지용 memberId 기준으로 조회

### DIFF
--- a/src/main/java/com/reform/wiz/controller/BoardController.java
+++ b/src/main/java/com/reform/wiz/controller/BoardController.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -89,5 +90,16 @@ public class BoardController {
 
     return ResponseEntity.ok(ApiResponse.success(resultDTO));
   }
+  
+  // 글 조회(유저별)
+  @GetMapping("/getBoards/{memberId}")
+  public ResponseEntity<ApiResponse<PageResponseDTO<BoardDTO>>> getBoardByMemberId(@RequestParam Map<String, Object> param, @PathVariable String memberId) {
+    int pageNum = (int) param.get("page");
 
+    Pageable page = PageRequestDTO.builder().page(pageNum).build().getPageable(Sort.by("bno"));
+
+    PageResponseDTO<BoardDTO> list = boardService.getBoardByMemberId(memberId, page);
+    
+    return ResponseEntity.ok(ApiResponse.success(list));
+  }
 }

--- a/src/main/java/com/reform/wiz/repository/BoardRepository.java
+++ b/src/main/java/com/reform/wiz/repository/BoardRepository.java
@@ -8,5 +8,6 @@ import com.reform.wiz.entity.BoardEntity;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
   Page<BoardEntity> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
-
+  
+  Page<BoardEntity> findByMemberEntity_MemberId(String memberId, Pageable page);
 }

--- a/src/main/java/com/reform/wiz/service/BoardService.java
+++ b/src/main/java/com/reform/wiz/service/BoardService.java
@@ -91,4 +91,13 @@ public class BoardService {
 
     return new BoardDTO(e);
   }
+
+  // 글 조회(유저별)
+  public PageResponseDTO<BoardDTO> getBoardByMemberId(String memberId, Pageable page) {
+    Page<BoardEntity> result = boardRepository.findByMemberEntity_MemberId(memberId, page);
+    Page<BoardDTO> list = result.map(BoardDTO::new);
+
+    return new PageResponseDTO<BoardDTO>(list);
+  }
+
 }

--- a/src/test/java/com/reform/wiz/service/BoardServiceTests.java
+++ b/src/test/java/com/reform/wiz/service/BoardServiceTests.java
@@ -1,8 +1,12 @@
 package com.reform.wiz.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.Commit;
 
 import com.reform.wiz.dto.BoardDTO;
+import com.reform.wiz.dto.PageRequestDTO;
 import com.reform.wiz.dto.PageResponseDTO;
 import com.reform.wiz.entity.File;
 
@@ -83,7 +88,10 @@ public class BoardServiceTests {
     int size = 10; // 고정
 
     Pageable pageable = PageRequest.of(pageNum, size, Sort.by("bno"));
-    PageResponseDTO<BoardDTO> result = boardService.getAllByPage(pageable);
+    Map<String, String> map = new HashMap<>();
+    map.put("title", "test");
+    map.put("content", "test");
+    PageResponseDTO<BoardDTO> result = boardService.getAllByPage(pageable, map);
 
     result.getDtoList().stream().forEach(e -> log.info(">>> list item : {} ", e));
 
@@ -128,5 +136,20 @@ public class BoardServiceTests {
 
     boardService.updateBoard(dto);
     log.info("after dto : {} ", dto.getIsDel());
+  }
+
+  @Test
+  public void 유저페이징글조회() {
+    Pageable page = PageRequestDTO.builder().page(1).build().getPageable(Sort.by("bno"));
+    PageResponseDTO<BoardDTO> res = boardService.getBoardByMemberId("loginUser", page);
+    
+    log.info(">>>>getMemberId {} ", res.getDtoList().get(0).getMemberId());
+
+    assertThat(res.getDtoList())
+    .isNotEmpty()
+    .allSatisfy(
+      dto -> assertThat(dto).isInstanceOf(BoardDTO.class)
+    );
+
   }
 }


### PR DESCRIPTION
### 작업내용
- 프로필에서 조회하는 작성자 기준 글쓰기 조회 api 추가
   > 페이징처리가 되어 있어 memberId와 page 번호에 맞게 응답처리됨